### PR TITLE
fix unset state.value field in grid map method

### DIFF
--- a/lib/grid.js
+++ b/lib/grid.js
@@ -128,14 +128,14 @@ Grid.prototype.all = function (s) {
 Grid.prototype.map = function (xOffset, yOffset, arr) {
   var state = [];
   for (var y = 0; y < 8; y++) {
-    if (typeof arr[y] == 'number') {
-      state[y].value = arr[y];
-      continue;
-    }
     state[y] = {
       type: 'integer',
       value: 0
     };
+    if (typeof arr[y] == 'number') {
+      state[y].value = arr[y];
+      continue;
+    }
     for (var x = 0; x < 8; x++) {
       state[y].value += (arr[y][x] << x);
     }


### PR DESCRIPTION
Seems like the state object wasn't initialized when trying to call grid#map with integer args. Have tested and that fixes that method for me. Not sure if there was another reason to leave that object unset that I'm missing though.

Thanks for the node bindings. This library is making my current project much simpler.

:) 